### PR TITLE
Correção no valor da Mark of Pilgrim no NPC Kiara

### DIFF
--- a/L2J_SunriseProject_Data/dist/game/data/multisell/custom/576002.xml
+++ b/L2J_SunriseProject_Data/dist/game/data/multisell/custom/576002.xml
@@ -113,7 +113,7 @@
 
 	<!-- Mark of Pilgrim -->
 	<item>
-		<ingredient id="57" count="1" />
+		<ingredient id="57" count="1000" />
 		<production id="2721" count="1" />
 	</item>
 


### PR DESCRIPTION
Valor estava como 1 Adena, o padrão é 1000 Adena.